### PR TITLE
Update ruler length to 280 characters per twitter change

### DIFF
--- a/etc/t-completion.zsh
+++ b/etc/t-completion.zsh
@@ -49,7 +49,7 @@ _t (){
       "retweet[Sends Tweets to your followers.]" \
       "retweets[Returns the 20 most recent Retweets by a user.]" \
       "retweets_of_me[Returns the 20 most recent Tweets of the authenticated user that have been retweeted by others.]" \
-      "ruler[Prints a 140-character ruler]" \
+      "ruler[Prints a 280-character ruler]" \
       "status[Retrieves detailed information about a Tweet.]" \
       "timeline[Returns the 20 most recent Tweets posted by a user.]" \
       "trends[Returns the top 50 trending topics.]" \

--- a/lib/t/cli.rb
+++ b/lib/t/cli.rb
@@ -688,10 +688,10 @@ module T
     end
     map %w(retweetsofme) => :retweets_of_me
 
-    desc 'ruler', 'Prints a 140-character ruler'
+    desc 'ruler', 'Prints a 280-character ruler'
     method_option 'indent', aliases: '-i', type: :numeric, default: 0, desc: 'The number of spaces to print before the ruler.'
     def ruler
-      markings = '----|'.chars.cycle.take(140).join
+      markings = '----|'.chars.cycle.take(280).join
       say "#{' ' * options['indent'].to_i}#{markings}"
     end
 


### PR DESCRIPTION
Per the recent Twitter update from 140-character to 280-character tweet lengths, a 140-character ruler is now obsolete. This supports the new 280-character max tweet length.